### PR TITLE
Badges de GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # Old-School Essentials SRD en español
+[![Publish docs via GitHub Pages](https://github.com/logoff/ose-srd-es/actions/workflows/build.yml/badge.svg)](https://github.com/logoff/ose-srd-es/actions/workflows/build.yml) [![pages-build-deployment](https://github.com/logoff/ose-srd-es/actions/workflows/pages/pages-build-deployment/badge.svg)](https://github.com/logoff/ose-srd-es/actions/workflows/pages/pages-build-deployment)
+
 Traducción del System Reference Document (SRD) de Old-School Essentials (OSE) al español.
 
 ## Requisitos


### PR DESCRIPTION
Esta PR añade badges de la publicación en GitHub Pages al README, usando los que se proporcionan por defecto en las GitHub Actions asociadas.