### PR TITLE
Usar GNU Make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,34 @@
+.PHONY: site-version
+site-version:
+	poetry version --short
+
+.PHONY: build-site
+build-site:
+	poetry install --no-root
+	poetry run mkdocs build
+
+.PHONY: clean-site
+clean-site:
+	rm -rf dist/
+
+.PHONY: serve-site
+serve-site:
+	poetry run mkdocs serve --dev-addr=0.0.0.0:8000
+
+.PHONY: publish-site
+publish-site: build-site
+	poetry run mkdocs gh-deploy --force
+
+.PHONY: docker-build
+docker-build:
+	docker image build --tag=ose-srd-es:$$(poetry version --short) .
+
+.PHONY: docker-serve-site
+docker-serve-site: docker-build
+	docker container run --rm -it \
+		-v $$(pwd)/mkdocs.yml:/site/mkdocs.yml \
+		-v $$(pwd)/src:/site/src \
+		-v $$(pwd)/main.py:/site/main.py \
+		-v $$(pwd)/.git:/site/.git \
+		-p 8000:8000 \
+		ose-srd-es:$$(poetry version --short)

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Traducción del System Reference Document (SRD) de Old-School Essentials (OSE) a
 
 * [Python](https://www.python.org/) 3.7+
 * [Poetry](https://python-poetry.org/)
+* [GNU Make](https://www.gnu.org/software/make/)
 * [Docker](https://www.docker.com/) (opcional)
 
 ## Desarrollo
@@ -14,8 +15,7 @@ Traducción del System Reference Document (SRD) de Old-School Essentials (OSE) a
 ### Sin Docker
 
 ```
-poetry install
-poetry run mkdocs serve --dev-addr=0.0.0.0:8000
+make serve-site
 ```
 
 Abrir http://localhost:8000/ en un navegador web.
@@ -26,19 +26,13 @@ Abrir http://localhost:8000/ en un navegador web.
 #### Construir la imagen
 
 ```
-docker build --tag=ose-srd-es:$(poetry version --short) .
+make docker-build
 ```
 
 #### Correr la imagen
 
 ```
-docker container run --rm -it \
-  -v $(pwd)/mkdocs.yml:/site/mkdocs.yml \
-  -v $(pwd)/src:/site/src \
-  -v $(pwd)/main.py:/site/main.py \
-  -v $(pwd)/.git:/site/.git \
-  -p 8000:8000 \
-  ose-srd-es:$(poetry version --short)
+make docker-serve-site
 ```
 
 Abrir http://localhost:8000/ en un navegador web.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ose-srd-es"
-version = "0.1.0"
+version = "0.1.1"
 description = "Traducción del System Reference Document (SRD) de Old-School Essentials (OSE) al español."
 authors = ["logoff"]
 license = "Open Game License v 1.0a"


### PR DESCRIPTION
Usar [GNU Make](https://www.gnu.org/software/make/) para encapsular mejor las tareas a ejecutar en el proyecto.