### PR TITLE
Corregir badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Old-School Essentials SRD en español
-[![Publish docs via GitHub Pages](https://github.com/logoff/ose-srd-es/actions/workflows/build.yml/badge.svg)](https://github.com/logoff/ose-srd-es/actions/workflows/build.yml) [![pages-build-deployment](https://github.com/logoff/ose-srd-es/actions/workflows/pages/pages-build-deployment/badge.svg)](https://github.com/logoff/ose-srd-es/actions/workflows/pages/pages-build-deployment)
+[![Publish docs via GitHub Pages](https://github.com/logoff/ose-srd-es/actions/workflows/build.yml/badge.svg)](https://github.com/logoff/ose-srd-es/actions/workflows/build.yml) [![pages-build-deployment](https://github.com/logoff/ose-srd-es/actions/workflows/pages/pages-build-deployment/badge.svg?branch=gh-pages)](https://github.com/logoff/ose-srd-es/actions/workflows/pages/pages-build-deployment)
 
 Traducción del System Reference Document (SRD) de Old-School Essentials (OSE) al español.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,7 @@ docs_dir: ./src/
 
 theme:
   name: material
+  language: es
   palette:
     scheme: ose
   logo: img/ose-logo.ico

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ose-srd-es"
-version = "0.2.0"
+version = "0.2.1"
 description = "Traducción del System Reference Document (SRD) de Old-School Essentials (OSE) al español."
 authors = ["logoff"]
 license = "Open Game License v 1.0a"


### PR DESCRIPTION
Usar badge en la branch correcta para la build de la web en GitHub Pages.

Además, usar español como lengua del tema, para que los textos aparezcan correctamente traducidos.